### PR TITLE
Rough proposal for making utm params (or more generally, attribution params) configurable at install time.

### DIFF
--- a/lib/generators/templates/create_universal_track_manager_tables.rb
+++ b/lib/generators/templates/create_universal_track_manager_tables.rb
@@ -11,15 +11,11 @@ class CreateUniversalTrackManagerTables < ActiveRecord::Migration<%= migration_v
 
       create_table :campaigns do |t|
         # this table gets automatically populated by inbound traffic
-        t.string :utm_source, limit: 50
-        t.string :utm_medium, limit: 50
-        t.string :utm_campaign, limit: 50
-        t.string :utm_content, limit: 50
-        t.string :utm_term, limit: 50
+        #GENERATOR INSERTS CAMPAIGN COLUMNS HERE
         t.timestamps
       end
 
-      add_index :campaigns, [:utm_source, :utm_medium, :utm_campaign, :utm_content, :utm_term], name: "utm_all_combined"
+      #GENERATOR INSERTS CAMPAIGN INDEX HERE
 
       create_table :visits do |t|
         t.datetime :first_pageload

--- a/lib/generators/templates/universal_track_manager.rb
+++ b/lib/generators/templates/universal_track_manager.rb
@@ -2,7 +2,7 @@ UniversalTrackManager.configure do |config|
   config.track_ips = true
   config.track_utms = true
   config.track_user_agent = true
-
+  #GENERATOR INSERTS CAMPAIGN COLUMN CONFIG HERE
 
   # config.track_referrer = false
 

--- a/lib/generators/universal_track_manager/install_generator.rb
+++ b/lib/generators/universal_track_manager/install_generator.rb
@@ -1,4 +1,5 @@
-require 'rails/generators/active_record'
+require 'rails/generators'
+
 
 module UniversalTrackManager
   class InstallGenerator < Rails::Generators::Base
@@ -9,6 +10,7 @@ module UniversalTrackManager
     source_root File.expand_path('../templates', __dir__)
 
     class_option :orm, type: 'boolean'
+    class_option :param_list, type: :string, default: 'utm_source,utm_medium,utm_campaign,utm_content,utm_term'
 
 
     def self.next_migration_number(path)
@@ -17,11 +19,23 @@ module UniversalTrackManager
 
     desc "Creates an initializer for Universal Track Manager and copy files to your application."
     def create_universal_track_manager_migration
-      migration_template "create_universal_track_manager_tables.rb",  "db/migrate/create_universal_track_manager_tables.rb"
+      @params = options['param_list']
+      column_defs = ""
+      @params.split(',').each  do |p|
+        column_defs += "t.string :#{p}, limit:256\n"
+      end
+      index_def = "add_index :campaigns, #{@params.split(',').map{|c| c.to_sym}.to_s}, name: 'utm_all_combined'"
+      copy_file "create_universal_track_manager_tables.rb", "#{self.class.source_root}/create_universal_track_manager_tables.rb-staged"
+      gsub_file "#{self.class.source_root}/create_universal_track_manager_tables.rb-staged", "#GENERATOR INSERTS CAMPAIGN COLUMNS HERE", column_defs
+      gsub_file "#{self.class.source_root}/create_universal_track_manager_tables.rb-staged", "#GENERATOR INSERTS CAMPAIGN INDEX HERE", index_def
+      migration_template "create_universal_track_manager_tables.rb-staged",  "db/migrate/create_universal_track_manager_tables.rb"
     end
 
     def create_universal_track_manager_initializer
-      copy_file 'universal_track_manager.rb', 'config/initializers/universal_track_manager.rb'
+      column_config = "config.campaign_columns = '#{options.param_list}'"
+      copy_file "universal_track_manager.rb", "#{self.class.source_root}/universal_track_manager.rb-staged"
+      gsub_file "#{self.class.source_root}/universal_track_manager.rb-staged", "#GENERATOR INSERTS CAMPAIGN COLUMN CONFIG HERE", column_config
+      copy_file 'universal_track_manager.rb-staged', 'config/initializers/universal_track_manager.rb'
     end
 
     def migration_version

--- a/lib/universal_track_manager.rb
+++ b/lib/universal_track_manager.rb
@@ -4,7 +4,7 @@ module UniversalTrackManager
   require "railtie.rb" if defined?(Rails)
 
   class Settings
-    attr_accessor :track_ips, :track_utms, :track_user_agent, :track_http_referrer
+    attr_accessor :track_ips, :track_utms, :track_user_agent, :track_http_referrer, :campaign_columns
   end
 
   def self.configure(&block)
@@ -12,7 +12,6 @@ module UniversalTrackManager
 
     block.call(@_settings)
   end
-
 
   def self.track_ips?
     @_settings.track_ips
@@ -29,6 +28,15 @@ module UniversalTrackManager
   def self.track_http_referrer?
     @_settings.track_http_referrer
   end
+
+  def self.campaign_column_names
+    @campaign_column_names ||= @_settings.campaign_columns.split(',')
+  end
+
+    def self.campaign_column_symbols
+    @campaign_column_symbols ||= @_settings.campaign_columns.split(',').map{|c| c.to_sym}
+  end
+
 end
 
 

--- a/lib/universal_track_manager/models/visit.rb
+++ b/lib/universal_track_manager/models/visit.rb
@@ -9,16 +9,17 @@ class UniversalTrackManager::Visit < ActiveRecord::Base
     if !campaign
       # this visit has no campaign, which means all UTMs = null
       # if any of the UTMs are present, return false (they don't match null)
-      return ! [:utm_campaign, :utm_source, :utm_medium, :utm_term, :utm_content].any? do |key|
+      return ! UniversalTrackManager.campaign_column_symbols.any? do |key|
         params[key].present?
       end
     end
 
     # note params are allowed to be missing
-    return campaign.utm_campaign == params[:utm_campaign] &&
-      campaign.utm_source == params[:utm_source] &&
-      campaign.utm_medium == params[:utm_medium] &&
-      campaign.utm_term == params[:utm_term] &&
-      campaign.utm_content == params[:utm_content]
+    UniversalTrackManager.campaign_column_symbols.each do |c|
+      if campaign[c] != params[c]
+        return false
+      end
+    end
+    return true
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@ end
 require "dummy/application"
 
 require "rspec/rails"
+
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 Dummy::Application.initialize!
@@ -25,6 +26,7 @@ UniversalTrackManager.configure do |config|
   config.track_ips = true
   config.track_utms = true
   config.track_user_agent = true
+  config.campaign_columns = 'utm_source,utm_campaign,utm_medium,utm_content,utm_term'
 end
 
 RSpec.configure do |config|
@@ -55,6 +57,7 @@ RSpec.configure do |config|
       config.track_utms = true
       config.track_http_referrer = true
       config.track_user_agent = true
+      config.campaign_columns = 'utm_source,utm_campaign,utm_medium,utm_content,utm_term'
     end
 
     restore_default_warning_free_config


### PR DESCRIPTION


 * utm_params defult to the standard set: utm_source,utm_campaign,utm_medium,utm_content,utm_term
 * when running generator, defaults can be overridden:
 * eg :  bundle exec rails generate universal_track_manager:install --param_list "utm_source,utm_campaign,utm_medium,utm_content,keyword,match_type"